### PR TITLE
Removed unnecessary Unity and PInvoke references from BulletSharp

### DIFF
--- a/Plugins/BulletUnity/BulletSharp/Collision/CollisionWorld.cs
+++ b/Plugins/BulletUnity/BulletSharp/Collision/CollisionWorld.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
 using BulletSharp.Math;
-using AOT;
 
 namespace BulletSharp
 {
@@ -140,7 +139,6 @@ namespace BulletSharp
 				GCHandle.ToIntPtr(handle));
         }
 
-		[MonoPInvokeCallback(typeof(AddSingleResultUnmanagedDelegate))]
 		static float AddSingleResultUnmanaged(IntPtr thisPtr, IntPtr cp, IntPtr colObj0Wrap, int partId0, int index0, IntPtr colObj1Wrap, int partId1, int index1)
         {
 			ContactResultCallback ai = GCHandle.FromIntPtr(thisPtr).Target as ContactResultCallback;
@@ -151,7 +149,6 @@ namespace BulletSharp
 
         public abstract float AddSingleResult(ManifoldPoint cp, CollisionObjectWrapper colObj0Wrap, int partId0, int index0, CollisionObjectWrapper colObj1Wrap, int partId1, int index1);
 
-		[MonoPInvokeCallback(typeof(NeedsCollisionUnmanagedDelegate))]
         static bool NeedsCollisionUnmanaged(IntPtr thisPtr, IntPtr proxy0)
         {
 			ContactResultCallback ai = GCHandle.FromIntPtr(thisPtr).Target as ContactResultCallback;
@@ -236,7 +233,6 @@ namespace BulletSharp
 				GCHandle.ToIntPtr(handle));
         }
 
-		[MonoPInvokeCallback(typeof(AddSingleResultUnmanagedDelegate))]
 		static float AddSingleResultUnmanaged(IntPtr ptrThis, IntPtr convexResult, bool normalInWorldSpace)
         {
 			ConvexResultCallback ptr = GCHandle.FromIntPtr(ptrThis).Target as ConvexResultCallback;
@@ -245,7 +241,6 @@ namespace BulletSharp
 
         public abstract float AddSingleResult(LocalConvexResult convexResult, bool normalInWorldSpace);
 
-		[MonoPInvokeCallback(typeof(NeedsCollisionUnmanagedDelegate))]
 		static bool NeedsCollisionUnmanaged(IntPtr ptrThis, IntPtr proxy0)
         {
 			ConvexResultCallback ptr = GCHandle.FromIntPtr(ptrThis).Target as ConvexResultCallback;
@@ -638,7 +633,6 @@ namespace BulletSharp
 				GCHandle.ToIntPtr(handle));
 		}
 
-		[MonoPInvokeCallback(typeof(AddSingleResultUnmanagedDelegate))]
         static float AddSingleResultUnmanaged(IntPtr thisPtr, IntPtr rayResult, bool normalInWorldSpace)
 		{
 			RayResultCallback ai = GCHandle.FromIntPtr(thisPtr).Target as RayResultCallback;
@@ -647,7 +641,6 @@ namespace BulletSharp
 
         public abstract float AddSingleResult(LocalRayResult rayResult, bool normalInWorldSpace);
 
-		[MonoPInvokeCallback(typeof(NeedsCollisionUnmanagedDelegate))]
 		static bool NeedsCollisionUnmanaged(IntPtr thisPtr, IntPtr proxy0)
 		{
 			RayResultCallback ai = GCHandle.FromIntPtr(thisPtr).Target as RayResultCallback;

--- a/Plugins/BulletUnity/BulletSharp/Collision/ManifoldPoint.cs
+++ b/Plugins/BulletUnity/BulletSharp/Collision/ManifoldPoint.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using BulletSharp.Math;
-using AOT;
 
 namespace BulletSharp
 {
@@ -29,7 +28,6 @@ namespace BulletSharp
         [UnmanagedFunctionPointer(Native.Conv), SuppressUnmanagedCodeSecurity]
         private delegate bool ContactAddedUnmanagedDelegate(IntPtr cp, IntPtr colObj0Wrap, int partId0, int index0, IntPtr colObj1Wrap, int partId1, int index1);
 
-		[MonoPInvokeCallback(typeof(ContactAddedUnmanagedDelegate))]
         static bool ContactAddedUnmanaged(IntPtr cp, IntPtr colObj0Wrap, int partId0, int index0, IntPtr colObj1Wrap, int partId1, int index1)
         {
             _contactAdded.Invoke(new ManifoldPoint(cp, true), new CollisionObjectWrapper(colObj0Wrap), partId0, index0, new CollisionObjectWrapper(colObj1Wrap), partId1, index1);

--- a/Plugins/BulletUnity/BulletSharp/Dynamics/DynamicsWorld.cs
+++ b/Plugins/BulletUnity/BulletSharp/Dynamics/DynamicsWorld.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security;
 using BulletSharp.Math;
-using AOT;
 
 namespace BulletSharp
 {
@@ -172,7 +171,6 @@ namespace BulletSharp
         }
         */
 
-        [MonoPInvokeCallback(typeof(InternalTickCallbackUnmanaged))]
         static private void InternalTickCallbackNative(IntPtr world, float timeStep)
         {
             CollisionWorld cw = _native2ManagedMap[world];

--- a/Plugins/BulletUnity/BulletSharp/Dynamics/IAction.cs
+++ b/Plugins/BulletUnity/BulletSharp/Dynamics/IAction.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
-using AOT;
 
 namespace BulletSharp
 {
@@ -42,7 +41,6 @@ namespace BulletSharp
         }
 
 		//changed these so they are static fuctions and have MonoPInvokeCallback decorator so they work from iOS (uses AOT)
-		[MonoPInvokeCallback(typeof(DebugDrawUnmanagedDelegate))]
         private static void DebugDrawUnmanaged(IntPtr iaPtrThis, IntPtr debugDrawer)
         {
 			//UnityEngine.Debug.Log("callback dd yes!");
@@ -51,7 +49,6 @@ namespace BulletSharp
         }
 
 		//changed these so they are static fuctions and have MonoPInvokeCallback decorator so they work from iOS (uses AOT)
-		[MonoPInvokeCallback(typeof(UpdateActionUnmanagedDelegate))]
         private static void UpdateActionUnmanaged(IntPtr iaPtrThis, IntPtr collisionWorld, float deltaTimeStep)
         {
 			//UnityEngine.Debug.Log("Callback yes!! " + iaPtrThis.ToInt64());

--- a/Plugins/BulletUnity/BulletSharp/InvalidDataException.cs
+++ b/Plugins/BulletUnity/BulletSharp/InvalidDataException.cs
@@ -1,5 +1,4 @@
-﻿using UnityEngine;
-using System;
+﻿using System;
 using System.Collections;
 
 namespace BulletSharp {

--- a/Plugins/BulletUnity/BulletSharp/LinearMath/MotionState.cs
+++ b/Plugins/BulletUnity/BulletSharp/LinearMath/MotionState.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using BulletSharp.Math;
-using AOT;
 
 namespace BulletSharp
 {
@@ -36,7 +35,6 @@ namespace BulletSharp
 				GCHandle.ToIntPtr(handle));
         }
 
-		[MonoPInvokeCallback(typeof(GetWorldTransformUnmanagedDelegate))]
         static void GetWorldTransformUnmanaged(IntPtr msPtr, out Matrix worldTrans)
         {
 			//UnityEngine.Debug.Log("Get" + msPtr.ToInt64());
@@ -44,7 +42,6 @@ namespace BulletSharp
             ms.GetWorldTransform(out worldTrans);
         }
 
-		[MonoPInvokeCallback(typeof(SetWorldTransformUnmanagedDelegate))]
         static void SetWorldTransformUnmanaged(IntPtr msPtr, ref Matrix worldTrans)
         {
 			//UnityEngine.Debug.Log("Set" + msPtr.ToInt64());

--- a/Plugins/BulletUnity/BulletSharp/Math/Matrix.cs
+++ b/Plugins/BulletUnity/BulletSharp/Math/Matrix.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace BulletSharp.Math
@@ -38,17 +39,17 @@ namespace BulletSharp.Math
     public struct Matrix : IEquatable<Matrix>, IFormattable
     {
         /// <summary>
-        /// The size of the <see cref="SlimMath.Matrix"/> type, in bytes.
+        /// The size of the <see cref="Matrix"/> type, in bytes.
         /// </summary>
         public static readonly int SizeInBytes = Marshal.SizeOf(typeof(Matrix));
 
         /// <summary>
-        /// A <see cref="SlimMath.Matrix"/> with all of its components set to zero.
+        /// A <see cref="Matrix"/> with all of its components set to zero.
         /// </summary>
         public static readonly Matrix Zero = new Matrix();
 
         /// <summary>
-        /// The identity <see cref="SlimMath.Matrix"/>.
+        /// The identity <see cref="Matrix"/>.
         /// </summary>
         public static readonly Matrix Identity = new Matrix() { M11 = 1.0f, M22 = 1.0f, M33 = 1.0f, M44 = 1.0f };
 
@@ -133,7 +134,7 @@ namespace BulletSharp.Math
         public float M44;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SlimMath.Matrix"/> struct.
+        /// Initializes a new instance of the <see cref="Matrix"/> struct.
         /// </summary>
         /// <param name="value">The value that will be assigned to all components.</param>
         public Matrix(float value)
@@ -145,7 +146,7 @@ namespace BulletSharp.Math
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SlimMath.Matrix"/> struct.
+        /// Initializes a new instance of the <see cref="Matrix"/> struct.
         /// </summary>
         /// <param name="M11">The value to assign at row 1 column 1 of the matrix.</param>
         /// <param name="M12">The value to assign at row 1 column 2 of the matrix.</param>
@@ -175,7 +176,7 @@ namespace BulletSharp.Math
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SlimMath.Matrix"/> struct.
+        /// Initializes a new instance of the <see cref="Matrix"/> struct.
         /// </summary>
         /// <param name="values">The values to assign to the components of the matrix. This must be an array with sixteen elements.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
@@ -326,7 +327,7 @@ namespace BulletSharp.Math
 
                 if (trace > 0.0f)
                 {
-                    float s = UnityEngine.Mathf.Sqrt(trace + (1.0f));
+                    float s = (float)System.Math.Sqrt(trace + (1.0f));
                     temp[3] = (s * (0.5f));
                     s = (0.5f) / s;
 
@@ -342,7 +343,7 @@ namespace BulletSharp.Math
                     int j = (i + 1) % 3;
                     int k = (i + 2) % 3;
 
-                    float s = UnityEngine.Mathf.Sqrt(this[i,i] - this[j,j] - this[k,k] + 1.0f);
+                    float s = (float)System.Math.Sqrt(this[i,i] - this[j,j] - this[k,k] + 1.0f);
                     temp[i] = s * 0.5f;
                     s = 0.5f / s;
 
@@ -355,7 +356,7 @@ namespace BulletSharp.Math
             set
             {
                 float d = value.X * value.X + value.Y * value.Y + value.Z * value.Z + value.W * value.W;
-                UnityEngine.Debug.Assert(d != 0.0f);
+                Debug.Assert(d != 0.0f);
                 float s = 2.0f / d;
                 float xs = value.X * s, ys = value.Y * s, zs = value.Z * s;
                 float wx = value.W * xs, wy = value.W * ys, wz = value.W * zs;
@@ -2902,11 +2903,11 @@ namespace BulletSharp.Math
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="SlimMath.Matrix"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Matrix"/> is equal to this instance.
         /// </summary>
-        /// <param name="other">The <see cref="SlimMath.Matrix"/> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Matrix"/> to compare with this instance.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="SlimMath.Matrix"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Matrix"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(Matrix other)
         {
@@ -2932,12 +2933,12 @@ namespace BulletSharp.Math
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="SlimMath.Matrix"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Matrix"/> is equal to this instance.
         /// </summary>
-        /// <param name="other">The <see cref="SlimMath.Matrix"/> to compare with this instance.</param>
+        /// <param name="other">The <see cref="Matrix"/> to compare with this instance.</param>
         /// <param name="epsilon">The amount of error allowed.</param>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="SlimMath.Matrix"/> is equal to this instance; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="Matrix"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(Matrix other, float epsilon)
         {

--- a/Plugins/BulletUnity/BulletSharp/SoftBody/SoftBody.cs
+++ b/Plugins/BulletUnity/BulletSharp/SoftBody/SoftBody.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security;
 using BulletSharp.Math;
-using AOT;
 
 namespace BulletSharp.SoftBody
 {
@@ -304,14 +303,12 @@ namespace BulletSharp.SoftBody
                 }
 			}
 
-			[MonoPInvokeCallback(typeof(PrepareUnmanagedDelegate))]
             static private void PrepareUnmanaged(IntPtr thisPtr,IntPtr aJoint)
             {
 				IControl ms = GCHandle.FromIntPtr(thisPtr).Target as IControl;
                 ms.Prepare(new AngularJoint(aJoint));
             }
 
-			[MonoPInvokeCallback(typeof(SpeedUnmanagedDelegate))]
             static public float SpeedUnmanaged(IntPtr thisPtr, IntPtr aJoint, float current)
             {
 				IControl ms = GCHandle.FromIntPtr(thisPtr).Target as IControl;


### PR DESCRIPTION
Works as before without the attributes, tested on Windows Editor & build with both Mono backing and I2cpp backed scripting and on Linux on Editor with Mono backing scripting. Removed all UnityEngine references