### PR TITLE
Make the BCapsuleShape gizmo work with properly with LocalScaling applied

### DIFF
--- a/Scripts/BUtility.cs
+++ b/Scripts/BUtility.cs
@@ -229,7 +229,7 @@ namespace BulletUnity {
 
             Gizmos.color = color;
 
-            radius *= radius * scale[(((int)upAxis) + 2) % 3];
+            radius *= scale[(((int)upAxis) + 2) % 3];
             halfHeight *= scale[(int)upAxis];
 
             Vector3 capStart = new Vector3(0.0f, 0.0f, 0.0f);

--- a/Scripts/BUtility.cs
+++ b/Scripts/BUtility.cs
@@ -225,9 +225,12 @@ namespace BulletUnity {
 
         public static void DebugDrawCapsule(Vector3 position, Quaternion rotation, Vector3 scale, float radius, float halfHeight, int upAxis, Color color) {
 
-            Matrix4x4 matrix = Matrix4x4.TRS(position, rotation, scale);
+            Matrix4x4 matrix = Matrix4x4.Translate(position)*Matrix4x4.Rotate(rotation);
 
             Gizmos.color = color;
+
+            radius *= radius * scale[(((int)upAxis) + 2) % 3];
+            halfHeight *= scale[(int)upAxis];
 
             Vector3 capStart = new Vector3(0.0f, 0.0f, 0.0f);
             capStart[upAxis] = -halfHeight;

--- a/Scripts/CollisionShapes/BCapsuleShape.cs
+++ b/Scripts/CollisionShapes/BCapsuleShape.cs
@@ -87,8 +87,9 @@ namespace BulletUnity
             {
                 rotation = Quaternion.AngleAxis(90, transform.right) * rotation;
             }
-            BUtility.DebugDrawCapsule(position, rotation, LocalScaling, radius, height / 2f, 1, Gizmos.color);
-
+            float scaledRadius = radius * LocalScaling[(((int)upAxis) + 2) % 3];
+            float scaledHeight = height * LocalScaling[(int)upAxis];
+            BUtility.DebugDrawCapsule(position, rotation, Vector3.one, scaledRadius, scaledHeight / 2f, 1, Gizmos.color);
         }
 
         CapsuleShape _CreateCapsuleShape()

--- a/Scripts/CollisionShapes/BCapsuleShape.cs
+++ b/Scripts/CollisionShapes/BCapsuleShape.cs
@@ -87,9 +87,8 @@ namespace BulletUnity
             {
                 rotation = Quaternion.AngleAxis(90, transform.right) * rotation;
             }
-            float scaledRadius = radius * LocalScaling[(((int)upAxis) + 2) % 3];
-            float scaledHeight = height * LocalScaling[(int)upAxis];
-            BUtility.DebugDrawCapsule(position, rotation, Vector3.one, scaledRadius, scaledHeight / 2f, 1, Gizmos.color);
+            BUtility.DebugDrawCapsule(position, rotation, LocalScaling, radius, height / 2f, 1, Gizmos.color);
+
         }
 
         CapsuleShape _CreateCapsuleShape()


### PR DESCRIPTION
Without this the tube lines don't extend all the way to the end spheres if the capsule is stretched along its vertical axis, and the radius isn't increased with scaling along other axes as it is internally in Bullet.